### PR TITLE
Add certification transfer capability and issuer staking mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,28 @@ A blockchain-based platform for tracking professional certifications and skills 
 - Track certification expiration
 - Add endorsements to certifications
 - Query certification history
+- Transfer certifications between users
+- Issuer staking mechanism for enhanced trust
 
 ## Usage
 The contract provides functions for:
+- Organizations to stake STX and become authorized issuers
 - Organizations to issue certifications
 - Users to claim and manage their certifications
+- Users to transfer their certifications
 - Anyone to verify certification validity
 - Adding skill endorsements
 - Tracking certification expiration dates
+
+## Issuer Staking
+To ensure trust and accountability, issuers must stake a minimum amount of STX tokens to be authorized to issue certifications. The staking mechanism includes:
+- Minimum stake requirement
+- Ability to increase stake
+- Controlled unstaking process
+- Automatic status updates based on stake amount
+
+## Certification Transfer
+Certifications can optionally be made transferable at the time of issuance. This enables:
+- Transfer of certifications between users
+- Maintaining certification history
+- Preserving endorsements during transfers


### PR DESCRIPTION
This PR introduces two major enhancements to the SkillSphere platform:

1. Certification Transfer System
- Allows issuers to create transferable certifications
- Enables recipients to transfer their certifications to other users
- Maintains certification history and endorsements
- Includes proper authorization checks and transfer restrictions

2. Issuer Staking Mechanism
- Requires issuers to stake STX tokens to maintain their issuer status
- Minimum stake requirement of 1,000,000 microSTX
- Ability to increase stake amount
- Controlled unstaking process with minimum balance requirements
- Enhanced trust through economic incentives

Technical Implementation:
- Added new transferable field to certification data structure
- Implemented transfer-certification function with proper checks
- Created stake-and-activate-issuer and unstake-issuer functions
- Enhanced authorized-issuers map to track stake amounts
- Added comprehensive tests for new functionality
- Updated documentation

Benefits:
- Increased platform security through economic staking
- Enhanced flexibility for certification management
- Greater trust in certification issuers
- Improved utility for certification holders

Migration Notes:
- Existing certifications will be non-transferable by default
- Existing issuers will need to stake tokens to maintain their status